### PR TITLE
Tzshift only via lua

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -19,7 +19,7 @@ Output record represents a normalized record shared by all logged applications. 
 script is configured for the application, Klogproc will only call the Lua-defined transformation function which means that the default conversion is omitted. For use cases where the default conversion is still required and the purpose of the Lua script is just to customise the default conversion, it can be called explicitly:
 
 ```lua
-local out = transform_default(input_rec, tz_offset_min)
+local out = transform_default(input_rec)
 -- modify the output
 -- ...
 ```
@@ -117,10 +117,33 @@ As mentioned above, if a Lua script is defined for an application, Klogproc will
 ```lua
 -- transform function processes the input record and returns an output record
 function transform(input_rec)
-    local out = transform_default(input_rec, 0)
+    local out = transform_default(input_rec)
     -- now we modify the Path property already set by transform_default
 	set_out_prop(
         out, "Path", string.format("%s/modified/value", input_rec.Path))
     return out
 end
 ```
+
+
+## Function datetime_add_minutes(num_min)
+
+The `datetime_add_minutes` allows for shifting log record time forwards and backwards
+to correct possible timezone issues.
+
+```lua
+function transform(input_rec)
+    local out = transform_default(input_rec)
+    datetime_add_minutes(out, -120)
+    return out
+end
+```
+
+## Function is_before_datetime(rec, datetime)
+
+The `is_before_datetime` tests whether the `rec` record has its datetime property before
+the provided `datetime` argument. The format is `2006-01-02T15:04:05-07:00`.
+
+## Function is_after_datetime(rec, datetime)
+
+The `is_after_datetime` is analogous to the `is_before_datetime`.

--- a/scripting/mock_test.go
+++ b/scripting/mock_test.go
@@ -109,6 +109,11 @@ func (r *dummyOutRec) GetTime() time.Time {
 	return r.time
 }
 
+func (r *dummyOutRec) SetTime(t time.Time) {
+	r.Time = t.Format(time.RFC3339)
+	r.time = t
+}
+
 func (r *dummyOutRec) LSetProperty(name string, value lua.LValue) error {
 	return ErrScriptingNotSupported
 }

--- a/scripting/regtrans.go
+++ b/scripting/regtrans.go
@@ -101,5 +101,39 @@ func registerStaticTransformer[T servicelog.LogItemTransformer](
 		return 0
 	}))
 
+	L.SetGlobal("is_before_datetime", L.NewFunction(func(l *lua.LState) int {
+		orec := checkOutputRecord(L, 1)
+		value := L.CheckString(2)
+		dt, err := time.Parse("2006-01-02T15:04:05", value)
+		if err != nil {
+			L.RaiseError("failed to parse datetime argument: %s", err.Error())
+			return 0
+		}
+		ans := orec.GetTime().Before(dt)
+		lv, err := ValueToLua(L, reflect.ValueOf(ans))
+		if err != nil {
+			L.RaiseError("failed to run preprocess(): %s", err)
+		}
+		L.Push(lv)
+		return 1
+	}))
+
+	L.SetGlobal("is_after_datetime", L.NewFunction(func(l *lua.LState) int {
+		orec := checkOutputRecord(L, 1)
+		value := L.CheckString(2)
+		dt, err := time.Parse("2006-01-02T15:04:05", value)
+		if err != nil {
+			L.RaiseError("failed to parse datetime argument: %s", err.Error())
+			return 0
+		}
+		ans := orec.GetTime().After(dt)
+		lv, err := ValueToLua(L, reflect.ValueOf(ans))
+		if err != nil {
+			L.RaiseError("failed to run preprocess(): %s", err)
+		}
+		L.Push(lv)
+		return 1
+	}))
+
 	return nil
 }

--- a/scripts/kwords2.lua
+++ b/scripts/kwords2.lua
@@ -3,7 +3,7 @@ function preprocess (log_rec, buffer)
 end
 
 function transform (input_rec)
-    local out = transform_default(input_rec, 0)
+    local out = transform_default(input_rec)
     if input_rec.Headers["x-is-web-app"] == "1" or input_rec.Headers["x-is-web-app"] == "true" then
         set_out_prop(out, "IsAPI", false)
     else

--- a/servicelog/apiguard/output.go
+++ b/servicelog/apiguard/output.go
@@ -64,6 +64,11 @@ func (cnkr *OutputRecord) GetTime() time.Time {
 	return cnkr.datetime
 }
 
+func (cnkr *OutputRecord) SetTime(t time.Time) {
+	cnkr.Datetime = t.Format(time.RFC3339)
+	cnkr.datetime = t
+}
+
 func (cnkr *OutputRecord) SetLocation(countryName string, latitude float32, longitude float32, timezone string) {
 	cnkr.GeoIP.IP = cnkr.IPAddress
 	cnkr.GeoIP.CountryName = countryName

--- a/servicelog/common.go
+++ b/servicelog/common.go
@@ -252,6 +252,9 @@ type OutputRecord interface {
 	// Get time of the log record
 	GetTime() time.Time
 
+	// Set time of the log record (this is used for Lua scripting)
+	SetTime(t time.Time)
+
 	// LSetProperty is used for dynamic property setting from within Lua environment.
 	// In case the output record does not (yet) support such property access, the
 	// method should return ErrScriptingNotSupported (but any returned error will

--- a/servicelog/kontext013/output.go
+++ b/servicelog/kontext013/output.go
@@ -119,6 +119,11 @@ func (cnkr *OutputRecord) GetTime() time.Time {
 	return cnkr.datetime
 }
 
+func (cnkr *OutputRecord) SetTime(t time.Time) {
+	cnkr.Datetime = t.Format(time.RFC3339)
+	cnkr.datetime = t
+}
+
 func (cnkr *OutputRecord) SetLocation(countryName string, latitude float32, longitude float32, timezone string) {
 	cnkr.GeoIP.IP = cnkr.IPAddress
 	cnkr.GeoIP.CountryName = countryName

--- a/servicelog/kontext015/output.go
+++ b/servicelog/kontext015/output.go
@@ -88,13 +88,6 @@ type OutputRecord struct {
 	Args           map[string]interface{}   `json:"args"`
 }
 
-// SetTime is defined for other treq variants
-// so they can all share the same output rec. type
-func (cnkr *OutputRecord) SetTime(t time.Time) {
-	cnkr.Datetime = t.Format(time.RFC3339)
-	cnkr.time = t
-}
-
 // ToJSON converts self to JSON string
 func (cnkr *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(cnkr)
@@ -112,6 +105,11 @@ func (cnkr *OutputRecord) GetType() string {
 // date and time when the record was created.
 func (cnkr *OutputRecord) GetTime() time.Time {
 	return cnkr.time
+}
+
+func (cnkr *OutputRecord) SetTime(t time.Time) {
+	cnkr.Datetime = t.Format(time.RFC3339)
+	cnkr.time = t
 }
 
 func (cnkr *OutputRecord) SetLocation(countryName string, latitude float32, longitude float32, timezone string) {

--- a/servicelog/korpusdb/output.go
+++ b/servicelog/korpusdb/output.go
@@ -78,6 +78,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 func (rec *OutputRecord) GenerateDeterministicID() string {
 	str := rec.Type + rec.Path + rec.Datetime + rec.IPAddress + rec.UserID + rec.QueryType +
 		strconv.Itoa(rec.Page.From) + strconv.Itoa(rec.Page.Size)

--- a/servicelog/kwords/output.go
+++ b/servicelog/kwords/output.go
@@ -82,6 +82,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 func (r *OutputRecord) GenerateDeterministicID() string {
 	rls := ""
 	if r.RefLength != nil {

--- a/servicelog/kwords2/output.go
+++ b/servicelog/kwords2/output.go
@@ -90,6 +90,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 func (r *OutputRecord) GenerateDeterministicID() string {
 	var uid string
 	if r.UserID != nil {

--- a/servicelog/mapka/output.go
+++ b/servicelog/mapka/output.go
@@ -72,6 +72,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/mapka2/output.go
+++ b/servicelog/mapka2/output.go
@@ -71,6 +71,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/mapka3/output.go
+++ b/servicelog/mapka3/output.go
@@ -74,6 +74,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/masm/output.go
+++ b/servicelog/masm/output.go
@@ -62,6 +62,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/morfio/output.go
+++ b/servicelog/morfio/output.go
@@ -81,6 +81,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 func (r *OutputRecord) GenerateDeterministicID() string {
 	str := r.Type + r.Datetime + r.IPAddress + r.UserID + r.KeyReq + r.KeyUsed +
 		r.Key + r.RunScript + r.Corpus + strconv.Itoa(r.MinFreq) + r.InputAttr + r.OutputAttr +

--- a/servicelog/mquery/output.go
+++ b/servicelog/mquery/output.go
@@ -65,6 +65,11 @@ func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.datetime = t
+}
+
 // SetLocation sets all the location related properties
 func (r *OutputRecord) SetLocation(countryName string, latitude float32, longitude float32, timezone string) {
 	r.GeoIP.IP = r.IPAddress

--- a/servicelog/mquerysru/output.go
+++ b/servicelog/mquerysru/output.go
@@ -61,6 +61,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.datetime
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.datetime = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/shiny/output.go
+++ b/servicelog/shiny/output.go
@@ -76,6 +76,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/ske/output.go
+++ b/servicelog/ske/output.go
@@ -87,6 +87,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/syd/output.go
+++ b/servicelog/syd/output.go
@@ -81,6 +81,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 func (r *OutputRecord) LSetProperty(name string, value lua.LValue) error {
 	return scripting.ErrScriptingNotSupported
 }

--- a/servicelog/treq/output.go
+++ b/servicelog/treq/output.go
@@ -50,13 +50,6 @@ type OutputRecord struct {
 	GeoIP       servicelog.GeoDataRecord `json:"geoip,omitempty"`
 }
 
-// SetTime is defined for other treq variants
-// so they can all share the same output rec. type
-func (r *OutputRecord) SetTime(t time.Time) {
-	r.Datetime = t.Format(time.RFC3339)
-	r.time = t
-}
-
 // SetLocation sets all the location related properties
 func (r *OutputRecord) SetLocation(countryName string, latitude float32, longitude float32, timezone string) {
 	r.GeoIP.IP = r.IPAddress
@@ -86,6 +79,11 @@ func (r *OutputRecord) GetType() string {
 // GetTime returns a creation time of the record
 func (r *OutputRecord) GetTime() time.Time {
 	return r.time
+}
+
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
 }
 
 func (r *OutputRecord) GenerateDeterministicID() string {

--- a/servicelog/vlo/output.go
+++ b/servicelog/vlo/output.go
@@ -58,6 +58,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.datetime
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.datetime = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/wag06/output.go
+++ b/servicelog/wag06/output.go
@@ -78,6 +78,11 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.Datetime = t.Format(time.RFC3339)
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/servicelog/wsserver/output.go
+++ b/servicelog/wsserver/output.go
@@ -69,6 +69,10 @@ func (r *OutputRecord) GetTime() time.Time {
 	return r.time
 }
 
+func (r *OutputRecord) SetTime(t time.Time) {
+	r.time = t
+}
+
 // ToJSON converts data to a JSON document (typically for ElasticSearch)
 func (r *OutputRecord) ToJSON() ([]byte, error) {
 	return json.Marshal(r)

--- a/stubgen.go
+++ b/stubgen.go
@@ -202,7 +202,7 @@ end
 
 -- transform function processes the input record and returns an output record
 function transform(input_rec)
-    local out = transform_default(input_rec, 0)
+    local out = transform_default(input_rec)
 	-- setting an output field:
 	set_out_prop(out, "{{.FirstFieldName}}", string.format("%s[modified]", input_rec.{{.FirstFieldName}}))
     -- TODO: Transform input record to output format


### PR DESCRIPTION
This should help preventing from generating different duplicated records after datetime corrections and repeated log processing.

The proper solution now should look like this:

```lua

function transform(input_rec)
    local out = transform_default(input_rec)
    -- only records after the script update milestone should be ever corrected
    if is_after_datetime(out, "2025-06-05T13:00:00")
        datetime_add_minutes(out, -120)
    end
    return out
end

```