### PR TITLE
Run conf. validation after logging is configured ...

### DIFF
--- a/klogproc.go
+++ b/klogproc.go
@@ -117,11 +117,11 @@ func help(topic string) {
 
 func setup(confPath, action string) *config.Main {
 	conf := config.Load(confPath)
-	config.Validate(conf, action)
 	if conf.Logging.Level == "" {
 		conf.Logging.Level = "info"
 	}
 	logging.SetupLogging(conf.Logging)
+	config.Validate(conf, action)
 	return conf
 }
 


### PR DESCRIPTION
... so we can see validation results in our log (except for log initialization errors, which is obvious)